### PR TITLE
Harden extract-outlinks.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@ buildNumber.properties
 # Avoid ignoring Maven wrapper jar file (.jar files are usually ignored)
 !/.mvn/wrapper/maven-wrapper.jar
 .idea
-veidemann-dbadapter.iml
+veidemann-rethinkdbadapter.iml

--- a/src/main/resources/default_objects/browser-scripts.yaml
+++ b/src/main/resources/default_objects/browser-scripts.yaml
@@ -17,7 +17,9 @@ browserScript:
             var outlinks = Array.prototype.slice.call(frame.document.querySelectorAll('a[href]'));
             for (var i = 0; i < frame.frames.length; i++) {
                 if (frame.frames[i] && !__brzl_framesDone.has(frame.frames[i])) {
-                    outlinks = outlinks.concat(__brzl_compileOutlinks(frame.frames[i]));
+                    try {
+                        outlinks = outlinks.concat(__brzl_compileOutlinks(frame.frames[i]));
+                    } catch {}
                 }
             }
         }


### PR DESCRIPTION
Prevents the script that extracts outlinks from crashing when trying to extract outlinks on specific frames (because CORS).