### PR TITLE
Ignore expire time for redis locks to guarantie resonable settings

### DIFF
--- a/src/main/java/no/nb/nna/veidemann/db/RethinkDbConnection.java
+++ b/src/main/java/no/nb/nna/veidemann/db/RethinkDbConnection.java
@@ -204,7 +204,7 @@ public class RethinkDbConnection implements DbServiceSPI {
     @Override
     public DistributedLock createDistributedLock(Key key, int expireSeconds) {
         if (useRedisLock) {
-            return new RedisDistributedLock(this, key, expireSeconds);
+            return new RedisDistributedLock(this, key);
         } else {
             return new RethinkDbDistributedLock(this, key, expireSeconds);
         }


### PR DESCRIPTION
Ignore expire time for redis locks to guarantee resonable settings all over (this is a temporary fix)

Handle unlock of expired lock