### PR TITLE
Only aggregate execution states per job execution when requesting specific id's

### DIFF
--- a/src/main/java/no/nb/nna/veidemann/db/RethinkDbExecutionsAdapter.java
+++ b/src/main/java/no/nb/nna/veidemann/db/RethinkDbExecutionsAdapter.java
@@ -123,7 +123,7 @@ public class RethinkDbExecutionsAdapter implements ExecutionsAdapter {
                         }
                     }
                     JobExecutionStatus jes = ProtoUtils.rethinkToProto(co, JobExecutionStatus.class);
-                    if (!jes.hasEndTime()) {
+                    if (jobExecutionsListRequest.getIdList().size() > 0 && !jes.hasEndTime()) {
                         LOG.debug("JobExecution '{}' is still running. Aggregating stats snapshot", jes.getId());
                         try {
                             Map sums = summarizeJobExecutionStats(jes.getId());


### PR DESCRIPTION
Job executions with a large number of executions is too heavy a workload when requesting lists.