### PR TITLE
Enable filtering on fields not present in row

### DIFF
--- a/src/test/java/no/nb/nna/veidemann/db/RethinkAstDecompilerTest.java
+++ b/src/test/java/no/nb/nna/veidemann/db/RethinkAstDecompilerTest.java
@@ -87,4 +87,19 @@ class RethinkAstDecompilerTest {
         ReqlAst ast2 = r.table("mintabell").getAll("foo", "bar").filter((row) -> row.eq(r.array("ugh")));
         assertThat(RethinkAstDecompiler.isEqual(ast1, ast2)).isTrue();
     }
+
+    @Test
+    void testDefault() {
+        ReqlAst ast = r.table("mintabell").filter(p1 -> p1.g("foo").default_("").eq("foo"));
+        String expected = "r.table(\"mintabell\").filter(p1 -> p1.g(\"foo\").default(\"\").eq(\"foo\"))";
+        assertThat(new RethinkAstDecompiler(ast).toString()).isEqualTo(expected);
+    }
+
+    @Test
+    void testHasFields() {
+        ReqlAst ast = r.table("mintabell").getAll("foo").filter(p1 -> p1.hasFields("foo"));
+        String expected = "r.table(\"mintabell\").getAll(\"foo\").filter(p1 -> p1.hasFields(\"foo\"))";
+
+        assertThat(new RethinkAstDecompiler(ast).toString()).isEqualTo(expected);
+    }
 }

--- a/src/test/java/no/nb/nna/veidemann/db/queryoptimizer/QueryOptimizerForConfigObjectsTest.java
+++ b/src/test/java/no/nb/nna/veidemann/db/queryoptimizer/QueryOptimizerForConfigObjectsTest.java
@@ -16,6 +16,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class QueryOptimizerForConfigObjectsTest {
     @Test
+    public void testListConfigObjectsBoolean() throws DbException {
+        ReqlAst q;
+        ReqlAst expected;
+        ListRequest.Builder req;
+
+        // Test list seed by a boolean queryMask
+        req = ListRequest.newBuilder().setKind(seed);
+        req.getQueryTemplateBuilder().getSeedBuilder().setDisabled(false);
+        req.getQueryMaskBuilder().addPaths("seed.disabled");
+        q = new ListConfigObjectQueryBuilder(req.build()).getListQuery();
+        expected = r.table("config_seeds")
+                .filter(p1 -> p1.g("seed").g("disabled").default_(false).eq(false));
+        assertThat(new RethinkAstDecompiler(q)).isEqualTo(new RethinkAstDecompiler(expected));
+    }
+
+    @Test
     public void testListConfigObjects() throws DbException {
         ReqlAst q;
         ReqlAst expected;
@@ -225,7 +241,7 @@ class QueryOptimizerForConfigObjectsTest {
         q = new ListConfigObjectQueryBuilder(req.build()).getListQuery();
         expected = r.table("config").getAll(r.array("browserScript", "bs1"))
                 .optArg("index", "configRefs")
-                .filter(p1 -> p1.g("kind").eq("browserConfig"));
+                .filter(p1 -> p1.g("kind").default_("undefined").eq("browserConfig"));
         assertThat(new RethinkAstDecompiler(q)).isEqualTo(new RethinkAstDecompiler(expected));
 
         // Test list browserConfig by two scriptRefs using template filter
@@ -240,7 +256,7 @@ class QueryOptimizerForConfigObjectsTest {
         q = new ListConfigObjectQueryBuilder(req.build()).getListQuery();
         expected = r.table("config").getAll(r.array("browserScript", "bs1"), r.array("browserScript", "bs2"))
                 .optArg("index", "configRefs")
-                .filter(p1 -> p1.g("kind").eq("browserConfig"));
+                .filter(p1 -> p1.g("kind").default_("undefined").eq("browserConfig"));
         assertThat(new RethinkAstDecompiler(q)).isEqualTo(new RethinkAstDecompiler(expected));
 
         // Test order
@@ -252,7 +268,7 @@ class QueryOptimizerForConfigObjectsTest {
         q = new ListConfigObjectQueryBuilder(req.setKind(crawlScheduleConfig).build()).getListQuery();
         expected = r.table("config").between(r.array("aaa", "bbb"), r.array("aaa", "bbb"))
                 .optArg("right_bound", "closed").optArg("index", "label")
-                .filter(p2 -> p2.g("kind").eq("crawlScheduleConfig"))
+                .filter(p2 -> p2.g("kind").default_("undefined").eq("crawlScheduleConfig"))
                 .orderBy(p1 -> p1.g("meta").g("name").downcase());
         assertThat(new RethinkAstDecompiler(q)).isEqualTo(new RethinkAstDecompiler(expected));
 
@@ -271,7 +287,7 @@ class QueryOptimizerForConfigObjectsTest {
         q = new ListConfigObjectQueryBuilder(req.setKind(crawlScheduleConfig).build()).getListQuery();
         expected = r.table("config").between(r.array("aaa", "bbb"), r.array("aaa", "bbb"))
                 .optArg("right_bound", "closed").optArg("index", "label")
-                .filter(p2 -> p2.g("kind").eq("crawlScheduleConfig"))
+                .filter(p2 -> p2.g("kind").default_("undefined").eq("crawlScheduleConfig"))
                 .orderBy(r.desc(p1 -> p1.g("meta").g("name").downcase()));
         assertThat(new RethinkAstDecompiler(q)).isEqualTo(new RethinkAstDecompiler(expected));
 
@@ -291,7 +307,7 @@ class QueryOptimizerForConfigObjectsTest {
         q = new ListConfigObjectQueryBuilder(req.setKind(crawlScheduleConfig).build()).getListQuery();
         expected = r.table("config").between(r.array("aaa", "bbb"), r.array("aaa", "bbb"))
                 .optArg("right_bound", "closed").optArg("index", "label")
-                .filter(p2 -> p2.g("kind").eq("crawlScheduleConfig"))
+                .filter(p2 -> p2.g("kind").default_("undefined").eq("crawlScheduleConfig"))
                 .orderBy(p1 -> p1.g("meta").g("lastModified"));
         assertThat(new RethinkAstDecompiler(q)).isEqualTo(new RethinkAstDecompiler(expected));
 
@@ -313,7 +329,7 @@ class QueryOptimizerForConfigObjectsTest {
         expected = r.table("config").between(r.array("aaa", "bbb"), r.array("aaa", "bbb"))
                 .optArg("right_bound", "closed").optArg("index", "label")
                 .orderBy().optArg("index", "label")
-                .filter(p3 -> p3.g("kind").eq("crawlScheduleConfig"))
+                .filter(p3 -> p3.g("kind").default_("undefined").eq("crawlScheduleConfig"))
                 .filter(p1 -> p1.g("meta").g("name").match("(?i)c[s|j]"));
         assertThat(new RethinkAstDecompiler(q)).isEqualTo(new RethinkAstDecompiler(expected));
 
@@ -330,7 +346,7 @@ class QueryOptimizerForConfigObjectsTest {
                 .setNameRegex("c[s|j].[1|3]");
         q = new ListConfigObjectQueryBuilder(req.setKind(crawlScheduleConfig).build()).getListQuery();
         expected = r.table("config").orderBy().optArg("index", "label")
-                .filter(p2 -> p2.g("kind").eq("crawlScheduleConfig"))
+                .filter(p2 -> p2.g("kind").default_("undefined").eq("crawlScheduleConfig"))
                 .filter(p1 -> p1.g("meta").g("name").match("(?i)c[s|j].[1|3]"));
         assertThat(new RethinkAstDecompiler(q)).isEqualTo(new RethinkAstDecompiler(expected));
 
@@ -377,7 +393,7 @@ class QueryOptimizerForConfigObjectsTest {
         q = new ListConfigObjectQueryBuilder(req.setKind(crawlScheduleConfig).build()).getListQuery();
         expected = r.table("config").between(r.array("foo", "bar"), r.array("foo", "bar"))
                 .optArg("right_bound", "closed").optArg("index", "label")
-                .filter(p1 -> p1.g("kind").eq("crawlScheduleConfig"));
+                .filter(p1 -> p1.g("kind").default_("undefined").eq("crawlScheduleConfig"));
         assertThat(new RethinkAstDecompiler(q)).isEqualTo(new RethinkAstDecompiler(expected));
 
         q = new ListConfigObjectQueryBuilder(req.setKind(seed).build()).getListQuery();
@@ -411,7 +427,7 @@ class QueryOptimizerForConfigObjectsTest {
         q = new ListConfigObjectQueryBuilder(req.setKind(crawlScheduleConfig).build()).getListQuery();
         expected = r.table("config").between(r.array("home", "run"), r.array("home", "run"))
                 .optArg("right_bound", "closed").optArg("index", "label")
-                .filter(p1 -> p1.g("kind").eq("crawlScheduleConfig"));
+                .filter(p1 -> p1.g("kind").default_("undefined").eq("crawlScheduleConfig"));
         assertThat(new RethinkAstDecompiler(q)).isEqualTo(new RethinkAstDecompiler(expected));
 
         q = new ListConfigObjectQueryBuilder(req.setKind(seed).build()).getListQuery();
@@ -426,7 +442,7 @@ class QueryOptimizerForConfigObjectsTest {
         q = new ListConfigObjectQueryBuilder(req.setKind(crawlScheduleConfig).build()).getListQuery();
         expected = r.table("config").between("foo", "foo")
                 .optArg("index", "label_value").optArg("right_bound", "closed")
-                .filter(p1 -> p1.g("kind").eq("crawlScheduleConfig"));
+                .filter(p1 -> p1.g("kind").default_("undefined").eq("crawlScheduleConfig"));
         assertThat(new RethinkAstDecompiler(q)).isEqualTo(new RethinkAstDecompiler(expected));
 
         q = new ListConfigObjectQueryBuilder(req.setKind(seed).build()).getListQuery();
@@ -441,7 +457,7 @@ class QueryOptimizerForConfigObjectsTest {
         q = new ListConfigObjectQueryBuilder(req.setKind(crawlScheduleConfig).build()).getListQuery();
         expected = r.table("config").between("foo", "foo\uFFFF")
                 .optArg("index", "label_value").optArg("right_bound", "closed")
-                .filter(p1 -> p1.g("kind").eq("crawlScheduleConfig"));
+                .filter(p1 -> p1.g("kind").default_("undefined").eq("crawlScheduleConfig"));
         assertThat(new RethinkAstDecompiler(q)).isEqualTo(new RethinkAstDecompiler(expected));
 
         q = new ListConfigObjectQueryBuilder(req.setKind(seed).build()).getListQuery();

--- a/src/test/java/no/nb/nna/veidemann/db/queryoptimizer/QueryOptimizerForCrawlExecutionsTest.java
+++ b/src/test/java/no/nb/nna/veidemann/db/queryoptimizer/QueryOptimizerForCrawlExecutionsTest.java
@@ -54,7 +54,7 @@ class QueryOptimizerForCrawlExecutionsTest {
                 .addId("id2")
                 .addState(State.CREATED);
         q = new ListCrawlExecutionQueryBuilder(req.build()).getListQuery();
-        expected = r.table("executions").getAll("id2").filter(p1 -> p1.g("state").eq("CREATED"));
+        expected = r.table("executions").getAll("id2").filter(p1 -> p1.g("state").default_("UNDEFINED").eq("CREATED"));
         assertThat(new RethinkAstDecompiler(q)).isEqualTo(new RethinkAstDecompiler(expected));
     }
 
@@ -76,7 +76,7 @@ class QueryOptimizerForCrawlExecutionsTest {
                 .addState(State.CREATED)
                 .addId("id2");
         q = new ListCrawlExecutionQueryBuilder(req.build()).getListQuery();
-        expected = r.table("executions").getAll("id2").filter(p1 -> p1.g("state").eq("CREATED"));
+        expected = r.table("executions").getAll("id2").filter(p1 -> p1.g("state").default_("UNDEFINED").eq("CREATED"));
         assertThat(new RethinkAstDecompiler(q)).isEqualTo(new RethinkAstDecompiler(expected));
 
         // Test list by state and order by state
@@ -180,7 +180,7 @@ class QueryOptimizerForCrawlExecutionsTest {
         req.getQueryMaskBuilder().addPaths("jobId");
         q = new ListCrawlExecutionQueryBuilder(req.build()).getListQuery();
         expected = r.table("executions").getAll("CREATED").optArg("index", "state")
-                .filter(p1 -> p1.g("jobId").eq("jid1"));
+                .filter(p1 -> p1.g("jobId").default_("").eq("jid1"));
         assertThat(new RethinkAstDecompiler(q)).isEqualTo(new RethinkAstDecompiler(expected));
 
         // Test list by startTime and jobId

--- a/src/test/java/no/nb/nna/veidemann/db/queryoptimizer/QueryOptimizerForJobExecutionsTest.java
+++ b/src/test/java/no/nb/nna/veidemann/db/queryoptimizer/QueryOptimizerForJobExecutionsTest.java
@@ -49,7 +49,7 @@ class QueryOptimizerForJobExecutionsTest {
                 .addId("id2")
                 .addState(State.CREATED);
         q = new ListJobExecutionQueryBuilder(req.build()).getListQuery();
-        expected = r.table("job_executions").getAll("id2").filter(p1 -> p1.g("state").eq("CREATED"));
+        expected = r.table("job_executions").getAll("id2").filter(p1 -> p1.g("state").default_("UNDEFINED").eq("CREATED"));
         assertThat(new RethinkAstDecompiler(q)).isEqualTo(new RethinkAstDecompiler(expected));
     }
 
@@ -71,7 +71,7 @@ class QueryOptimizerForJobExecutionsTest {
                 .addState(State.CREATED)
                 .addId("id2");
         q = new ListJobExecutionQueryBuilder(req.build()).getListQuery();
-        expected = r.table("job_executions").getAll("id2").filter(p1 -> p1.g("state").eq("CREATED"));
+        expected = r.table("job_executions").getAll("id2").filter(p1 -> p1.g("state").default_("UNDEFINED").eq("CREATED"));
         assertThat(new RethinkAstDecompiler(q)).isEqualTo(new RethinkAstDecompiler(expected));
 
         // Test list by state and order by state
@@ -165,7 +165,7 @@ class QueryOptimizerForJobExecutionsTest {
         req.getQueryMaskBuilder().addPaths("jobId");
         q = new ListJobExecutionQueryBuilder(req.build()).getListQuery();
         expected = r.table("job_executions").getAll("CREATED").optArg("index", "state")
-                .filter(p1 -> p1.g("jobId").eq("jid1"));
+                .filter(p1 -> p1.g("jobId").default_("").eq("jid1"));
         assertThat(new RethinkAstDecompiler(q)).isEqualTo(new RethinkAstDecompiler(expected));
 
         // Test list by startTime and jobId

--- a/src/test/java/no/nb/nna/veidemann/db/queryoptimizer/QueryOptimizerTest.java
+++ b/src/test/java/no/nb/nna/veidemann/db/queryoptimizer/QueryOptimizerTest.java
@@ -2,6 +2,7 @@ package no.nb.nna.veidemann.db.queryoptimizer;
 
 import com.google.protobuf.util.Timestamps;
 import com.rethinkdb.ast.ReqlAst;
+import com.rethinkdb.gen.ast.Javascript;
 import no.nb.nna.veidemann.api.config.v1.ListRequest;
 import no.nb.nna.veidemann.commons.db.DbException;
 import no.nb.nna.veidemann.db.ListConfigObjectQueryBuilder;
@@ -32,13 +33,13 @@ class QueryOptimizerTest {
         lr.getQueryMaskBuilder().addPaths("meta.name");
         q = new ListConfigObjectQueryBuilder(lr.build()).getListQuery();
         expected = r.table("config").getAll("csc3").optArg("index", "name")
-                .filter((p1) -> p1.getField("kind").eq("crawlScheduleConfig"));
+                .filter((p1) -> p1.getField("kind").default_("undefined").eq("crawlScheduleConfig"));
         assertThat(new RethinkAstDecompiler(q)).isEqualTo(new RethinkAstDecompiler(expected));
 
         lr = req.clone();
         lr.getQueryMaskBuilder().addPaths("crawlScheduleConfig.validFrom");
         q = new ListConfigObjectQueryBuilder(lr.build()).getListQuery();
-        expected = r.table("config").filter(p1 -> p1.g("crawlScheduleConfig").g("validFrom")
+        expected = r.table("config").filter(p1 -> p1.g("crawlScheduleConfig").g("validFrom").default_((Javascript) null)
                 .eq(r.iso8601("2020-12-02T09:53:36.406Z")).and(p1.g("kind").eq("crawlScheduleConfig")));
         assertThat(new RethinkAstDecompiler(q)).isEqualTo(new RethinkAstDecompiler(expected));
     }


### PR DESCRIPTION
Fields matching default values in proto messages is not stored in documents which raises an
exception when trying to filter on such fields. This pull request amends this by forcing comparisons
to fall back to the default value when the field is not present.